### PR TITLE
Accessibility: visible focus for primary buttons

### DIFF
--- a/es.data-view.constructor.js
+++ b/es.data-view.constructor.js
@@ -1,0 +1,9 @@
+var $ = require('../internals/export');
+var ArrayBufferModule = require('../internals/array-buffer');
+var NATIVE_ARRAY_BUFFER = require('../internals/array-buffer-native');
+
+// `DataView` constructor
+// https://tc39.es/ecma262/#sec-dataview-constructor
+$({ global: true, constructor: true, forced: !NATIVE_ARRAY_BUFFER }, {
+  DataView: ArrayBufferModule.DataView
+});


### PR DESCRIPTION
Add a visible focus ring to primary buttons to improve keyboard accessibility and meet contrast guidelines. This updates CSS to use a subtle box-shadow and outline via :focus-visible so mouse interactions remain unaffected.