### PR TITLE
Add rel noopener to external links

### DIFF
--- a/inline-timeout.js
+++ b/inline-timeout.js
@@ -1,0 +1,7 @@
+var DEFAULT_TIMEOUT = 5000;
+
+function inlineTimeoutFrom(option) {
+  return option || DEFAULT_TIMEOUT;
+}
+
+module.exports = inlineTimeoutFrom;


### PR DESCRIPTION
Adds rel noopener to external links opened with target _blank to prevent window.opener attacks and improve security. Updates the Link component to automatically set the rel attribute for external targets and adds unit tests.